### PR TITLE
Fix import redirect 500 error

### DIFF
--- a/reports/site_sections/import.py
+++ b/reports/site_sections/import.py
@@ -77,5 +77,5 @@ class Root:
 
         all_instances = session.query(model).filter(model.id.in_(id_list)).all() if id_list else None
 
-        return self.csv_import(message, all_instances)
+        return self.index(message, all_instances)
     import_model.restricted = [c.ACCOUNTS and c.STATS and c.PEOPLE and c.MONEY]


### PR DESCRIPTION
Imports would work, but throw a 500 error because it would try to return a function that we took out when we moved this into its own plugin. This uses the correct function name.
