### PR TITLE
Remove base-admin.html

### DIFF
--- a/reports/templates/export/index.html
+++ b/reports/templates/export/index.html
@@ -1,4 +1,4 @@
-{% extends "base-admin.html" %}
+{% extends "base.html" %}{% set admin_area=True %}
 {% block title %}CSV Export{% endblock %}
 {% block content %}
 

--- a/reports/templates/import/index.html
+++ b/reports/templates/import/index.html
@@ -1,4 +1,4 @@
-{% extends "base-admin.html" %}
+{% extends "base.html" %}{% set admin_area=True %}
 {% block title %}CSV Import{% endblock %}
 {% block content %}
 


### PR DESCRIPTION
Now that we have Jinja2 templating, we can use the variable admin_area to control what gets included in child templates, rather than inheriting from a different template. We're implementing that now.